### PR TITLE
Remove AggregateId

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -64,14 +64,4 @@ class CouldNotSendNotification extends \Exception
     {
         return new static('SMS receiver not provided');
     }
-
-    /**
-     * Thrown when there is no 'aggregateId' provided
-     *
-     * @return static
-     */
-    public static function aggregateIdNotProvided()
-    {
-        return new static('Zenvia aggregateId not provided');
-    }
 }

--- a/src/Zenvia.php
+++ b/src/Zenvia.php
@@ -24,23 +24,18 @@ class Zenvia
     /** @var null|string from do zenvia. */
     protected $pretend = null;
 
-    /** @var null|string from do zenvia. */
-    protected $aggregateId = null;
-
     /**
      * @param null $conta
      * @param null $senha
      * @param null $from
      * @param false $pretend
-     * @param null $aggregateId
      */
-    public function __construct($conta = null, $senha = null, $from = null, $pretend = false, $aggregateId = null)
+    public function __construct($conta = null, $senha = null, $from = null, $pretend = false)
     {
         $this->conta        = $conta;
         $this->senha        = $senha;
         $this->from         = $from;
         $this->pretend      = $pretend;
-        $this->aggregateId  = $aggregateId;
     }
 
     /**
@@ -77,10 +72,6 @@ class Zenvia
             throw CouldNotSendNotification::senhaNotProvided();
         }
 
-        if(empty($this->aggregateId)){
-            throw CouldNotSendNotification::aggregateIdNotProvided();
-        }
-
         try {
             $data = [
                 'sendSmsRequest' => [
@@ -90,7 +81,6 @@ class Zenvia
                     'id'                => $params['id'],
                     'schedule'          => $params['schedule'] ?: '',
                     'callbackOption'    => $params['callbackOption'] ?: 'NONE',
-                    'aggregateId'       => $this->aggregateId,
                     'flashSms'          => $params['flashSms'] ?: true,
                 ],
             ];

--- a/src/ZenviaServiceProvider.php
+++ b/src/ZenviaServiceProvider.php
@@ -19,8 +19,7 @@ class ZenviaServiceProvider extends ServiceProvider
                     $config['conta'],
                     $config['senha'],
                     isset($config['from'])         ? $config['from']        : null,
-                    isset($config['pretend'])      ? $config['pretend']     : false,
-                    isset($config['aggregateId'])  ? $config['aggregateId'] : null
+                    isset($config['pretend'])      ? $config['pretend']     : false
                 );
             });
     }


### PR DESCRIPTION
"AggregateId" não é um campo obrigatório na documentação da Zenvia e sua validação quebra a utilização do programa.